### PR TITLE
refactor(litellm): Update configuration for LiteLLM demo

### DIFF
--- a/pocs/litellm/config.yaml
+++ b/pocs/litellm/config.yaml
@@ -7,16 +7,17 @@ description: "Demonstration of using LiteLLM with multiple LLM providers"
 
 # LLM Configuration
 models:
-  - "gpt-4o-mini"
-  - "ollama/llama3.2"
+  # - "gpt-4o-mini"
+  # - "ollama/llama3.2"
+  - "deepseek/deepseek-chat"
 
 
 # API Keys (not needed for Ollama)
 api_keys: {}
 
 # LLM Parameters
-max_tokens: 100
-prompt_template: "Explain the concept of neural networks in one sentence."
+max_tokens: 250
+prompt_template: "Explain the concept of neural networks in one paragraph."
 
 # Logging Configuration
 logging:


### PR DESCRIPTION
- Commented out previous model entries ("gpt-4o-mini" and "ollama/llama3.2") and added "deepseek/deepseek-chat" as the new model.
- Increased max_tokens from 100 to 250 to allow for more detailed responses.
- Updated prompt_template to request explanations in one paragraph instead of one sentence, enhancing the output quality.

These changes improve the flexibility and depth of the LiteLLM demonstration.

## Summary by Sourcery

Update the LiteLLM demo configuration to use the "deepseek/deepseek-chat" model, increase the maximum number of tokens to 250, and modify the prompt template to request paragraph-long explanations of neural networks.

Enhancements:
- Switch to the "deepseek/deepseek-chat" model for the LiteLLM demo.
- Increase the maximum number of tokens from 100 to 250 for more detailed responses.
- Modify the prompt template to request explanations in a paragraph instead of a sentence.