### PR TITLE
docs: update logo size to 50% in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Each POC contains its own README with specific setup instructions and requiremen
 
 ## Made with ❤️ and Human-Machine Collaboration
 
-![Cyborg Logo](cyborg.png)
+<img src="assets/cyborg.png" alt="Cyborg Logo" width="50%"/>
 
 This project represents the fusion of human creativity and machine intelligence, working together to push the boundaries of what's possible.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Resize the Cyborg logo to occupy 50% of its container width in the README.